### PR TITLE
Add mode to check if input is already formatted

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,11 +4,14 @@
 module Main (main) where
 
 import Control.Applicative (many, (<**>))
+import Control.Monad       (unless, when)
 import Data.Foldable       (asum, for_)
 import Data.Maybe          (fromMaybe)
+import Data.Traversable    (for)
 import Data.Version        (showVersion)
 import System.Exit         (exitFailure)
 import System.FilePath     (takeDirectory)
+import System.IO           (hPutStrLn, stderr)
 
 import qualified Data.ByteString     as BS
 import qualified Options.Applicative as O
@@ -23,14 +26,20 @@ import Paths_cabal_fmt (version)
 
 main :: IO ()
 main = do
-    (inplace, opts', filepaths) <- O.execParser optsP'
+    (opts', filepaths) <- O.execParser optsP'
     let opts = runOptionsMorphism opts' defaultOptions
 
-    case filepaths of
-        []    -> BS.getContents >>= main' False opts Nothing
-        (_:_) -> for_ filepaths $ \filepath -> do
+    notFormatted <- catMaybes <$> case filepaths of
+        []    -> fmap pure $ BS.getContents >>= main' opts Nothing
+        (_:_) -> for filepaths $ \filepath -> do
             contents <- BS.readFile filepath
-            main' inplace opts (Just filepath) contents
+            main' opts (Just filepath) contents
+
+    when ((optMode opts == ModeCheck) && not (null notFormatted)) $ do
+        for_ notFormatted $ \filepath ->
+            hPutStrLn stderr $ "error: Input " <> filepath <> " is not formatted."
+        exitFailure
+
   where
     optsP' = O.info (optsP <**> O.helper <**> versionP) $ mconcat
         [ O.fullDesc
@@ -41,8 +50,8 @@ main = do
     versionP = O.infoOption (showVersion version)
         $ O.long "version" <> O.help "Show version"
 
-main' :: Bool -> Options -> Maybe FilePath -> BS.ByteString -> IO ()
-main' inplace opts mfilepath input = do
+main' :: Options -> Maybe FilePath -> BS.ByteString -> IO (Maybe FilePath)
+main' opts mfilepath input = do
     -- name of the input
     let filepath = fromMaybe "<stdin>" mfilepath
 
@@ -50,10 +59,19 @@ main' inplace opts mfilepath input = do
     res <- runCabalFmtIO (takeDirectory <$> mfilepath) opts (cabalFmt filepath input)
 
     case res of
-        Right output
-            | inplace   -> BS.writeFile filepath outputBS
-            | otherwise -> BS.putStr outputBS
-          where outputBS = toUTF8BS output
+        Right output -> do
+            let outputBS = toUTF8BS output
+                formatted = outputBS == input
+
+            case optMode opts of
+                ModeStdout -> BS.putStr outputBS
+                ModeInplace -> case mfilepath of
+                    Nothing -> BS.putStr outputBS
+                    Just _  -> unless formatted $ BS.writeFile filepath outputBS
+                _ -> return ()
+
+            return $ if formatted then Nothing else Just filepath
+
         Left err     -> do
             renderError err
             exitFailure
@@ -62,10 +80,9 @@ main' inplace opts mfilepath input = do
 -- Options parser
 -------------------------------------------------------------------------------
 
-optsP :: O.Parser (Bool, OptionsMorphism, [FilePath])
-optsP = (,,)
-    <$> O.flag False True (O.short 'i' <> O.long "inplace" <> O.help "process files in-place")
-    <*> optsP'
+optsP :: O.Parser (OptionsMorphism, [FilePath])
+optsP = (,)
+    <$> optsP'
     <*> many (O.strArgument (O.metavar "FILE..." <> O.help "input files"))
   where
     optsP' = fmap mconcat $ many $ asum
@@ -74,6 +91,9 @@ optsP = (,,)
         , indentP
         , tabularP
         , noTabularP
+        , stdoutP
+        , inplaceP
+        , checkP
         ]
 
     werrorP = O.flag' (mkOptionsMorphism $ \opts -> opts { optError = True })
@@ -90,4 +110,13 @@ optsP = (,,)
 
     noTabularP = O.flag' (mkOptionsMorphism $ \opts -> opts { optTabular = False })
         $ O.long "no-tabular"
+
+    stdoutP = O.flag' (mkOptionsMorphism $ \opts -> opts { optMode = ModeStdout })
+        $ O.long "stdout" <> O.help "Write output to stdout (default)"
+
+    inplaceP = O.flag' (mkOptionsMorphism $ \opts -> opts { optMode = ModeInplace })
+        $ O.short 'i' <> O.long "inplace" <> O.help "Process files in-place"
+
+    checkP = O.flag' (mkOptionsMorphism $ \opts -> opts { optMode = ModeCheck })
+        $ O.short 'c' <> O.long "check" <> O.help "Fail with non-zero exit code if input is not formatted"
 

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -17,6 +17,7 @@ import CabalFmt         (cabalFmt)
 import CabalFmt.Error   (renderError)
 import CabalFmt.Monad   (runCabalFmtIO)
 import CabalFmt.Options
+import CabalFmt.Prelude
 
 import Paths_cabal_fmt (version)
 
@@ -50,8 +51,9 @@ main' inplace opts mfilepath input = do
 
     case res of
         Right output
-            | inplace   -> writeFile filepath output
-            | otherwise -> putStr output
+            | inplace   -> BS.writeFile filepath outputBS
+            | otherwise -> BS.putStr outputBS
+          where outputBS = toUTF8BS output
         Left err     -> do
             renderError err
             exitFailure

--- a/src/CabalFmt/Options.hs
+++ b/src/CabalFmt/Options.hs
@@ -2,6 +2,7 @@
 -- License: GPL-3.0-or-later
 -- Copyright: Oleg Grenrus
 module CabalFmt.Options (
+    Mode (..),
     Options (..),
     defaultOptions,
     OptionsMorphism, mkOptionsMorphism, runOptionsMorphism,
@@ -12,11 +13,18 @@ import Distribution.Compat.Lens (LensLike')
 
 import qualified Distribution.CabalSpecVersion       as C
 
+data Mode
+    = ModeStdout
+    | ModeInplace
+    | ModeCheck
+  deriving (Eq, Show)
+
 data Options = Options
     { optError       :: !Bool
     , optIndent      :: !Int
     , optTabular     :: !Bool
     , optSpecVersion :: !C.CabalSpecVersion
+    , optMode        :: !Mode
     }
   deriving Show
 
@@ -26,6 +34,7 @@ defaultOptions = Options
     , optIndent      = 2
     , optTabular     = True
     , optSpecVersion = C.cabalSpecLatest
+    , optMode        = ModeStdout
     }
 
 newtype OptionsMorphism = OM (Options -> Options)


### PR DESCRIPTION
Fixes #10.

This also changes the output behavior to use UTF-8 always instead of the system locale. Since Cabal expects UTF-8 input this seems correct to me but let me know if I'm missing something.