### PR TITLE
Add section in README on how to get format-on-save in Emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,17 @@ executable cabal-fmt
     OverloadedStrings
     RankNTypes
 ```
+
+## Editor Integration
+
+### Emacs
+
+If you have `cabal-fmt` in your `$PATH`, you can auto-format `.cabal` files in
+your project by putting this in the project directory's `.dir-locals.el`:
+
+```elisp
+((haskell-cabal-mode
+  (eval .
+    (add-hook 'before-save-hook
+      (lambda () (haskell-mode-buffer-apply-command "cabal-fmt")) nil t))))
+```


### PR DESCRIPTION
I'd put this in this repo's `.dir-locals.el` but then editing the fixtures would be difficult. :smile: 

If this tool catches on enough, we should get the lambda added to `haskell-mode` like `haskell-mode-stylish-buffer` for `stylish-haskell`.