### PR TITLE
Expose internal library

### DIFF
--- a/cabal-fmt.cabal
+++ b/cabal-fmt.cabal
@@ -22,13 +22,13 @@ source-repository head
   type:     git
   location: https://github.com/phadej/cabal-fmt.git
 
-library cabal-fmt-internal
+library
   default-language: Haskell2010
   hs-source-dirs:   src
 
   -- GHC boot libraries
   build-depends:
-    , base        ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0
+    , base        ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0
     , bytestring  ^>=0.10.8.2
     , Cabal       ^>=3.4.0.0
     , containers  ^>=0.5.11.0 || ^>=0.6.0.1
@@ -82,7 +82,7 @@ executable cabal-fmt
   build-depends:
     , base
     , bytestring
-    , cabal-fmt-internal
+    , cabal-fmt
     , directory
     , filepath
 
@@ -100,7 +100,7 @@ test-suite golden
     , base
     , bytestring
     , Cabal
-    , cabal-fmt-internal
+    , cabal-fmt
     , containers
 
   -- test dependencies

--- a/src/CabalFmt/Glob.hs
+++ b/src/CabalFmt/Glob.hs
@@ -2,7 +2,6 @@ module CabalFmt.Glob where
 
 import Data.List             (isInfixOf)
 import Data.List.NonEmpty    (NonEmpty (..))
-import System.FilePath.Posix (splitDirectories)
 
 import CabalFmt.Prelude
 


### PR DESCRIPTION
This allows usage of cabal-fmt as a library for other projects. 
Specifically I would like to use this for a cabal-fmt plugin I wrote for Haskell Language Server (https://github.com/VeryMilkyJoe/haskell-language-server/tree/cabal-fmt).