### PR TITLE
Fix windows build and tests

### DIFF
--- a/src/CabalFmt/Fields/SourceFiles.hs
+++ b/src/CabalFmt/Fields/SourceFiles.hs
@@ -16,7 +16,7 @@ import qualified Distribution.Pretty       as C
 import qualified Text.PrettyPrint          as PP
 
 import CabalFmt.Fields
-import CabalFmt.Prelude
+import CabalFmt.Prelude hiding (splitDirectories)
 
 sourceFilesF :: [FieldDescrs () ()]
 sourceFilesF =

--- a/src/CabalFmt/Glob.hs
+++ b/src/CabalFmt/Glob.hs
@@ -4,7 +4,7 @@ import Data.List             (isInfixOf)
 import Data.List.NonEmpty    (NonEmpty (..))
 import System.FilePath.Posix (splitDirectories)
 
-import CabalFmt.Prelude
+import CabalFmt.Prelude hiding (splitDirectories)
 
 data Glob = Glob FilePath [GlobPiece]
   deriving Show

--- a/tests/Golden.hs
+++ b/tests/Golden.hs
@@ -50,7 +50,7 @@ goldenTest' n = goldenTest n readGolden makeTest cmp writeGolden
                         return (toUTF8BS $ unlines (map ("-- " ++) ws) ++ output')
 
     cmp a b | a == b    = return Nothing
-            | otherwise = Just <$> readProcess' "diff" ["-u", goldenPath, "-"] (fromUTF8BS b)
+            | otherwise = Just <$> readProcess' "diff" ["-u", "--strip-trailing-cr", goldenPath, "-"] (fromUTF8BS b)
 
     readProcess' proc args input = do
         (_, out, _) <- readProcessWithExitCode proc args input


### PR DESCRIPTION
* The build failed in windows due to duplicate definitions for `splitDirectories`, one coming from posix and the oher from windows
* Tests throwed false negatives due to trailing crlf