### PR TITLE
Add support for cabal sub-libraries

### DIFF
--- a/fixtures/with-sublibs.cabal
+++ b/fixtures/with-sublibs.cabal
@@ -6,7 +6,7 @@ library
   hs-source-dirs:     src
   default-language:   Haskell2010
   build-depends: 
-    main1, 
-    main1:sub, 
-    main3 >=1 && <3, 
-    main3:sub >=2 && <4
+    test1, 
+    test1:sub, 
+    test2 >=1 && <3, 
+    test2:sub >=2 && <4

--- a/fixtures/with-sublibs.cabal
+++ b/fixtures/with-sublibs.cabal
@@ -1,0 +1,12 @@
+cabal-version: 3.0
+name:          with-sublibs
+version:       1
+
+library
+  hs-source-dirs:     src
+  default-language:   Haskell2010
+  build-depends: 
+    main1, 
+    main1:sub, 
+    main3 >=1 && <3, 
+    main3:sub >=2 && <4

--- a/fixtures/with-sublibs.format
+++ b/fixtures/with-sublibs.format
@@ -1,0 +1,11 @@
+Up to date
+cabal-version: 3.0
+name:          with-sublibs
+version:       1
+
+library
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  build-depends:
+    , test1:{test1, sub}
+    , test2:{test2, sub}  >=2 && <3

--- a/src/CabalFmt/Fields/BuildDepends.hs
+++ b/src/CabalFmt/Fields/BuildDepends.hs
@@ -59,11 +59,14 @@ pretty opts deps = case deps of
       where
         deps' :: [(String, [C.VersionInterval])]
         deps' = sortOn (map toLower . fst)
-              $ map (C.unPackageName . C.depPkgName &&& C.asVersionIntervals . C.depVerRange)
+              $ map (prettyDepNoVersion &&& C.asVersionIntervals . C.depVerRange)
               $ C.fromDepMap . C.toDepMap -- this combines duplicate packages
               $ deps
 
-  where
+        prettyDepNoVersion :: C.Dependency -> String
+        prettyDepNoVersion (C.Dependency pkg _ libs) = 
+          C.prettyShow (C.Dependency pkg C.anyVersion libs)
+
 
 prettyExe :: Options -> [C.ExeDependency] -> PP.Doc
 prettyExe opts deps = case deps of


### PR DESCRIPTION
Given a cabal file with build-inputs such as:
```
build-inputs:
  main,
  main:sub
``` 
The current parser would format the output as:
```
build-inputs:
  main
``` 
In other words, sublibraries would be lost.
This PR adresses this issue and adds a new test fixture.