### PR TITLE
Remove redundant imports

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,8 +4,7 @@
 module Main (main) where
 
 import Control.Applicative (many, (<**>))
-import Control.Monad       (unless, when)
-import Data.Foldable       (asum, for_)
+import Data.Foldable       (for_)
 import Data.Traversable    (for)
 import Data.Version        (showVersion)
 import System.Exit         (exitFailure)

--- a/src/CabalFmt.hs
+++ b/src/CabalFmt.hs
@@ -11,7 +11,6 @@ module CabalFmt (cabalFmt) where
 
 import Control.Monad        (join)
 import Control.Monad.Reader (asks, local)
-import Data.Either          (partitionEithers)
 
 import qualified Data.ByteString                              as BS
 import qualified Distribution.CabalSpecVersion                as C

--- a/src/CabalFmt/Fields/SourceFiles.hs
+++ b/src/CabalFmt/Fields/SourceFiles.hs
@@ -7,8 +7,6 @@ module CabalFmt.Fields.SourceFiles (
     fileFields,
     ) where
 
-import System.FilePath.Posix (splitDirectories)
-
 import qualified Distribution.FieldGrammar as C
 import qualified Distribution.Fields       as C
 import qualified Distribution.Parsec       as C

--- a/src/CabalFmt/Glob.hs
+++ b/src/CabalFmt/Glob.hs
@@ -2,7 +2,6 @@ module CabalFmt.Glob where
 
 import Data.List             (isInfixOf)
 import Data.List.NonEmpty    (NonEmpty (..))
-import System.FilePath.Posix (splitDirectories)
 
 import CabalFmt.Prelude
 


### PR DESCRIPTION
The lines `import System.FilePath.Posix (splitDirectories)` make it impossible to install cabal-fmt on windows. 