### PR TITLE
Explicitly use Posix's splitDirectories

### DIFF
--- a/src/CabalFmt/Fields/SourceFiles.hs
+++ b/src/CabalFmt/Fields/SourceFiles.hs
@@ -7,7 +7,9 @@ module CabalFmt.Fields.SourceFiles (
     fileFields,
     ) where
 
-import System.FilePath.Posix (splitDirectories)
+-- Make sure we explicitly use Posix's splitDirectories
+-- when parsing glob syntax since only `/` is valid, and not '\\'
+import qualified System.FilePath.Posix     as Posix (splitDirectories)
 
 import qualified Distribution.FieldGrammar as C
 import qualified Distribution.Fields       as C
@@ -46,7 +48,7 @@ pretty :: [FilePath] -> PP.Doc
 pretty
     = PP.vcat . map C.showFilePath
     . nub
-    . sortBy (cmp `on` map strToLower . splitDirectories)
+    . sortBy (cmp `on` map strToLower . Posix.splitDirectories)
   where
     cmp a b = case dropCommonPrefix a b of
         ([], [])  -> EQ

--- a/src/CabalFmt/Glob.hs
+++ b/src/CabalFmt/Glob.hs
@@ -2,7 +2,9 @@ module CabalFmt.Glob where
 
 import Data.List             (isInfixOf)
 import Data.List.NonEmpty    (NonEmpty (..))
-import System.FilePath.Posix (splitDirectories)
+-- Make sure we explicitly use Posix's splitDirectories
+-- when parsing glob syntax since only `/` is valid, and not '\\'
+import qualified System.FilePath.Posix as Posix (splitDirectories)
 
 import CabalFmt.Prelude
 
@@ -27,7 +29,7 @@ data GlobChar
 -- [False,False,True,True]
 --
 match :: Glob -> FilePath -> Bool
-match (Glob g1 gs0) fp = go0 (splitDirectories fp) where
+match (Glob g1 gs0) fp = go0 (Posix.splitDirectories fp) where
     go0 []     = False
     go0 (p:ps) = if p == g1 then go ps gs0 else False
 
@@ -47,7 +49,7 @@ match (Glob g1 gs0) fp = go0 (splitDirectories fp) where
     matches (x:xs) (GlobChar c : cs) = if x == c then matches xs cs else False
 
 parseGlob :: String -> Either String Glob
-parseGlob input = case splitDirectories input of
+parseGlob input = case Posix.splitDirectories input of
     []     -> Left "empty path"
     (x:xs) -> do
         p <- parseFirstPiece x


### PR DESCRIPTION
Fixes build on windows.

See logs from [HLS CI](https://github.com/haskell/haskell-language-server/runs/7264218634?check_suite_focus=true):
```
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - cabal-fmt-0.1.5.1 (lib:cabal-fmt-internal) (requires build)
 - ghc-check-0.5.0.6 (lib) (requires build)
 - ghc-exactprint-0.6.4 (lib) (requires build)
 - uuid-1.3.15 (lib) (requires build)
 - cabal-fmt-0.1.5.1 (exe:cabal-fmt) (requires build)
 - retrie-1.1.0.0 (lib) (requires build)
 - lsp-1.4.0.0 (lib) (requires build)
 - hls-plugin-api-1.4.0.0 (lib) (configuration changed)
 - ghcide-1.7.0.1 (lib) (configuration changed)
 - hls-test-utils-1.3.0.0 (lib) (configuration changed)
 - hls-cabal-fmt-plugin-0.1.0.0 (lib) (configuration changed)
 - hls-cabal-fmt-plugin-0.1.0.0 (test:tests) (first run)
Starting     ghc-check-0.5.0.6 (lib)
Starting     cabal-fmt-0.1.5.1 (lib:cabal-fmt-internal)
Building     ghc-check-0.5.0.6 (lib)
Building     cabal-fmt-0.1.5.1 (lib:cabal-fmt-internal)
Starting     ghc-exactprint-0.6.4 (lib)
Installing   ghc-check-0.5.0.6 (lib)
Completed    ghc-check-0.5.0.6 (lib)
Building     ghc-exactprint-0.6.4 (lib)
Installing   ghc-exactprint-0.6.4 (lib)
Completed    ghc-exactprint-0.6.4 (lib)
Failed to build lib:cabal-fmt-internal from cabal-fmt-0.1.5.1.
Build log (
C:\cabal\logs\ghc-8.10.7\cabal-fmt-0.1.5.1-edd3d86618a0e30a3d90a13e6d76b4ca89209696.log
):
Preprocessing library 'cabal-fmt-internal' for cabal-fmt-0.1.5.1..
Building library 'cabal-fmt-internal' for cabal-fmt-0.1.5.1..
[ 1 of 20] Compiling CabalFmt.Error   ( src\CabalFmt\Error.hs, dist\build\cabal-fmt-internal\CabalFmt\Error.o )
[ 2 of 20] Compiling CabalFmt.Options ( src\CabalFmt\Options.hs, dist\build\cabal-fmt-internal\CabalFmt\Options.o )
cabal.exe: Failed to build lib:cabal-fmt-internal from cabal-fmt-0.1.5.1
(which is required by test:tests from hls-cabal-fmt-plugin-0.1.0.0). See the
[ 3 of 20] Compiling CabalFmt.Monad   ( src\CabalFmt\Monad.hs, dist\build\cabal-fmt-internal\CabalFmt\Monad.o )
build log above for details.
[ 4 of 20] Compiling CabalFmt.Prelude ( src\CabalFmt\Prelude.hs, dist\build\cabal-fmt-internal\CabalFmt\Prelude.o )
[ 5 of 20] Compiling CabalFmt.Parser  ( src\CabalFmt\Parser.hs, dist\build\cabal-fmt-internal\CabalFmt\Parser.o )
[ 6 of 20] Compiling CabalFmt.Glob    ( src\CabalFmt\Glob.hs, dist\build\cabal-fmt-internal\CabalFmt\Glob.o )
src\CabalFmt\Glob.hs:30:31: error:
Error:     Ambiguous occurrence ‘splitDirectories’
    It could refer to
       either ‘System.FilePath.Posix.splitDirectories’,
              imported from ‘System.FilePath.Posix’ at src\CabalFmt\Glob.hs:5:31-46
           or ‘CabalFmt.Prelude.splitDirectories’,
              imported from ‘CabalFmt.Prelude’ at src\CabalFmt\Glob.hs:7:1-23
              (and originally defined in ‘System.FilePath.Windows’)
   |
30 | match (Glob g1 gs0) fp = go0 (splitDirectories fp) where
   |                               ^^^^^^^^^^^^^^^^
src\CabalFmt\Glob.hs:50:24: error:
Error:     Ambiguous occurrence ‘splitDirectories’
    It could refer to
       either ‘System.FilePath.Posix.splitDirectories’,
              imported from ‘System.FilePath.Posix’ at src\CabalFmt\Glob.hs:5:31-46
           or ‘CabalFmt.Prelude.splitDirectories’,
              imported from ‘CabalFmt.Prelude’ at src\CabalFmt\Glob.hs:7:1-23
              (and originally defined in ‘System.FilePath.Windows’)
   |
50 | parseGlob input = case splitDirectories input of
   |                        ^^^^^^^^^^^^^^^^
Build profile: -w ghc-8.10.7 -O1
``` 