### PR TITLE
fix emacs integration docs and add use-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ or in `use-package`:
   (revert-buffer nil t))
 
 (use-package haskell-cabal-mode
-  :straight nil
   :hook
   (before-save . my/haskell-cabal-format-and-save))
 ```

--- a/README.md
+++ b/README.md
@@ -70,10 +70,28 @@ If you have `cabal-fmt` in your `$PATH`, you can auto-format `.cabal` files in
 your project by putting this in the project directory's `.dir-locals.el`:
 
 ```elisp
+(defun my/haskell-cabal-format-and-save ()
+  "Format .cabal files with cabal-fmt."
+  (shell-command (format "cabal-fmt --inplace %s" (buffer-file-name)))
+  (revert-buffer nil t))
+
 ((haskell-cabal-mode
   (eval .
-    (add-hook 'before-save-hook
-      (lambda () (haskell-mode-buffer-apply-command "cabal-fmt")) nil t))))
+    (add-hook 'before-save-hook 'my/haskell-cabal-format-and-save nil t))))
+```
+
+or in `use-package`:
+
+```elisp
+(defun my/haskell-cabal-format-and-save ()
+  "Format .cabal files with cabal-fmt."
+  (shell-command (format "cabal-fmt --inplace %s" (buffer-file-name)))
+  (revert-buffer nil t))
+
+(use-package haskell-cabal-mode
+  :straight nil
+  :hook
+  (before-save . my/haskell-cabal-format-and-save))
 ```
 
 ### Vim


### PR DESCRIPTION
I am suggesting this edit because the original `README.md` description of how to make it work in *emacs* did not work for me. I believe the syntax `cabal-fmt --inplace <filename>` is necessary for it to work.

I am a user of [use-package](https://github.com/jwiegley/use-package), and was able to make it work seamlessly with the below code. I haven't tried `.dir-locals.el` after that, feel free to remove that part or change it in a suitable way. I feel it is important that the buffer is reverted once the changes are made, so one can actually see the result.