### PR TITLE
Allow setting root directory when reading from STDIN

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -52,8 +52,10 @@ main' opts mfilepath input = do
     -- name of the input
     let filepath = fromMaybe "<stdin>" mfilepath
 
+    let root = maybe (optRoot opts) Just $ fmap takeDirectory mfilepath
+
     -- process
-    res <- runCabalFmtIO (takeDirectory <$> mfilepath) opts (cabalFmt filepath input)
+    res <- runCabalFmtIO root opts (cabalFmt filepath input)
 
     case res of
         Right output -> do
@@ -93,6 +95,7 @@ optsP = (,)
         , stdoutP
         , inplaceP
         , checkP
+        , rootP
         ]
 
     werrorP = O.flag' (mkOptionsMorphism $ \opts -> opts { optError = True })
@@ -125,3 +128,5 @@ optsP = (,)
     checkP = O.flag' (mkOptionsMorphism $ \opts -> opts { optMode = ModeCheck })
         $ O.short 'c' <> O.long "check" <> O.help "Fail with non-zero exit code if input is not formatted"
 
+    rootP = O.option (fmap (\d -> mkOptionsMorphism $ \opts -> opts { optRoot = Just d }) O.str)
+        $ O.long "root" <> O.help "Sets the root directory when reading from STDIN" <> O.metavar "DIR"

--- a/src/CabalFmt/Options.hs
+++ b/src/CabalFmt/Options.hs
@@ -26,6 +26,7 @@ data Options = Options
     , optCabalFile   :: !Bool
     , optSpecVersion :: !C.CabalSpecVersion
     , optMode        :: !Mode
+    , optRoot        :: !(Maybe FilePath)
     }
   deriving Show
 
@@ -37,6 +38,7 @@ defaultOptions = Options
     , optCabalFile   = True
     , optSpecVersion = C.cabalSpecLatest
     , optMode        = ModeStdout
+    , optRoot        = Nothing
     }
 
 newtype OptionsMorphism = OM (Options -> Options)


### PR DESCRIPTION
Fixes #51.

This adds a new `--root DIR` option to the CLI. When reading input from STDIN, if the `--root` option is set, the `DIR` will be used when finding modules as part of the `-- cabal-fmt: expand some-directory` pragma. For example:

``` sh
# Works the same as before.
cabal-fmt some-package.cabal

# Also works the same as before. The `--root` option is silently ignored.
cabal-fmt --root ignored some-package.cabal

# Works the same as before. No root directory is set, so no expanding happens.
cabal-fmt < some-package.cabal

# New behavior! Root directory is set, so expanding happens even though we're reading from STDIN.
cabal-fmt --root . < some-package.cabal
```