### PR TITLE
Allow setting input file when reading from STDIN

### DIFF
--- a/src/CabalFmt/Options.hs
+++ b/src/CabalFmt/Options.hs
@@ -26,6 +26,7 @@ data Options = Options
     , optCabalFile   :: !Bool
     , optSpecVersion :: !C.CabalSpecVersion
     , optMode        :: !Mode
+    , optStdinInputFile :: !(Maybe FilePath)
     }
   deriving Show
 
@@ -37,6 +38,7 @@ defaultOptions = Options
     , optCabalFile   = True
     , optSpecVersion = C.cabalSpecLatest
     , optMode        = ModeStdout
+    , optStdinInputFile = Nothing
     }
 
 newtype OptionsMorphism = OM (Options -> Options)


### PR DESCRIPTION
Fixes #51. Alternative to #65. 

This adds a new `--stdin-input-file FILE` command-line option. It is intended to be used when reading a Cabal file from STDIN. The given `FILE` will be used to resolve relative references, which allows pragmas like `-- cabal-fmt: expand some-directory` to work even when reading from STDIN. 

I borrowed the flag name from Ormolu. I'm not set on it — if there's a better name, let's change it. 

Like #65, this does not let you set both `--stdin-input-file` and an actual input file. In other words, `cabal-fmt --stdin-input-file x y` is an error, even if `x` and `y` happen to be the same. 

I think this is preferable to #65 because it should be easier to integrate with tools. It's very common to have the file path of the file you want to format, along with the file's contents in memory. Requiring a directory name would require calling something like `dirname`, which is just an extra unnecessary step. 